### PR TITLE
feat : 로그인 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,21 @@ dependencies {
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Oauth2
+	implementation 'org.springframework.security:spring-security-oauth2-client'
+	implementation 'org.springframework.security:spring-security-oauth2-jose'
+
+	// Spring Cloud
+	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.0")
+
+	// Spring Cloud Open Feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pickkasso/PickkassoApplication.java
+++ b/src/main/java/com/pickkasso/PickkassoApplication.java
@@ -2,8 +2,10 @@ package com.pickkasso;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PickkassoApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/pickkasso/domain/auth/api/AuthController.java
+++ b/src/main/java/com/pickkasso/domain/auth/api/AuthController.java
@@ -1,0 +1,39 @@
+package com.pickkasso.domain.auth.api;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pickkasso.domain.auth.application.AuthService;
+import com.pickkasso.domain.auth.dto.request.AuthCodeRequest;
+import com.pickkasso.domain.auth.dto.response.TokenPairResponse;
+import com.pickkasso.global.util.CookieUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+    private final CookieUtil cookieUtil;
+
+    @PostMapping("/code")
+    public ResponseEntity<TokenPairResponse> memberOauthRegister(
+            @RequestBody AuthCodeRequest request) {
+        TokenPairResponse tokenPairResponse = authService.socialLogin(request.getCode());
+        String accessToken = tokenPairResponse.getAccessToken();
+        String refreshToken = tokenPairResponse.getRefreshToken();
+        HttpHeaders httpHeaders = cookieUtil.generateTokenCookies(accessToken, refreshToken);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .headers(httpHeaders)
+                .body(tokenPairResponse);
+    }
+}

--- a/src/main/java/com/pickkasso/domain/auth/application/AuthService.java
+++ b/src/main/java/com/pickkasso/domain/auth/application/AuthService.java
@@ -1,0 +1,66 @@
+package com.pickkasso.domain.auth.application;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pickkasso.domain.auth.dto.response.GoogleTokenResponse;
+import com.pickkasso.domain.auth.dto.response.TokenPairResponse;
+import com.pickkasso.domain.member.dao.MemberRepository;
+import com.pickkasso.domain.member.domain.Member;
+import com.pickkasso.domain.member.domain.OauthInfo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+    private final IdTokenVerifier idTokenVerifier;
+    private final MemberRepository memberRepository;
+    private final GoogleTokenService googleTokenService;
+    private final JwtTokenService jwtTokenService;
+
+    public TokenPairResponse socialLogin(String authcode) {
+        GoogleTokenResponse response = googleTokenService.getGoogleTokenResponse(authcode);
+        OidcUser oidcUser = idTokenVerifier.getOidcUser(response.getIdToken());
+        OauthInfo oauthInfo = OauthInfo.createOauthInfo(oidcUser);
+
+        Member member = getMemberByOidcInfo(oidcUser, oauthInfo);
+        googleTokenService.saveGoogleRefreshToken(member.getId(), response.getRefreshToken());
+
+        setAuthenticationToken(oidcUser);
+
+        return getLoginResponse(member);
+    }
+
+    private Member getMemberByOidcInfo(OidcUser oidcUser, OauthInfo oauthInfo) {
+        return memberRepository
+                        .findByOauthInfo(oauthInfo)
+                        .orElseGet(() -> saveMember(oauthInfo, getUserSocialName(oidcUser)));
+    }
+
+    private String getUserSocialName(OidcUser oidcUser) {
+        return oidcUser.getClaim("name");
+    }
+
+    private TokenPairResponse getLoginResponse(Member member) {
+        String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
+        String refreshToken = jwtTokenService.createRefreshToken(member.getId());
+        return new TokenPairResponse(accessToken, refreshToken);
+    }
+
+    private void setAuthenticationToken(OidcUser oidcUser) {
+        OAuth2AuthenticationToken token =
+                new OAuth2AuthenticationToken(oidcUser, oidcUser.getAuthorities(), "google");
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private Member saveMember(OauthInfo oauthInfo, String nickname) {
+        return memberRepository.save(Member.createMember(oauthInfo, nickname));
+    }
+}

--- a/src/main/java/com/pickkasso/domain/auth/application/GoogleTokenService.java
+++ b/src/main/java/com/pickkasso/domain/auth/application/GoogleTokenService.java
@@ -1,0 +1,48 @@
+package com.pickkasso.domain.auth.application;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pickkasso.domain.auth.dao.GoogleRefreshTokenRepository;
+import com.pickkasso.domain.auth.domain.GoogleRefreshToken;
+import com.pickkasso.domain.auth.dto.response.GoogleTokenResponse;
+import com.pickkasso.infra.config.feign.GoogleApiClient;
+import com.pickkasso.infra.config.oauth.GoogleProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GoogleTokenService {
+    private static final String AUTHORIZATION_CODE = "authorization_code";
+
+    private final GoogleRefreshTokenRepository refreshTokenRepository;
+    private final GoogleApiClient googleApiClient;
+    private final GoogleProperties properties;
+
+    public GoogleTokenResponse getGoogleTokenResponse(String authcode) {
+        return googleApiClient.getToken(
+                        authcode,
+                        properties.getId(),
+                        properties.getSecret(),
+                        properties.getRedirectUri(),
+                        AUTHORIZATION_CODE);
+    }
+
+    public void saveGoogleRefreshToken(Long memberId, String newToken) {
+        Optional<GoogleRefreshToken> tokenOptional = refreshTokenRepository.findById(memberId);
+        if (tokenOptional.isPresent()) {
+            GoogleRefreshToken savedToken = tokenOptional.get();
+            savedToken.setToken(newToken);
+            return;
+        }
+        GoogleRefreshToken newGoogleRefreshToken =
+                GoogleRefreshToken.builder().memberId(memberId).token(newToken).build();
+        refreshTokenRepository.save(newGoogleRefreshToken);
+    }
+}

--- a/src/main/java/com/pickkasso/domain/auth/application/IdTokenVerifier.java
+++ b/src/main/java/com/pickkasso/domain/auth/application/IdTokenVerifier.java
@@ -1,0 +1,69 @@
+package com.pickkasso.domain.auth.application;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import com.pickkasso.global.error.exception.CustomException;
+import com.pickkasso.global.error.exception.ErrorCode;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+import com.pickkasso.global.common.constants.SecurityConstants;
+import com.pickkasso.infra.config.oauth.GoogleProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class IdTokenVerifier {
+    private final GoogleProperties properties;
+    private final JwtDecoder jwtDecoder = buildDecoder();
+
+    public OidcUser getOidcUser(String idToken) {
+        Jwt jwt = jwtDecoder.decode(idToken);
+        OidcIdToken oidcIdToken =
+                new OidcIdToken(idToken, jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
+
+        validateIssuer(oidcIdToken);
+        validateExpired(oidcIdToken);
+        validateAudience(oidcIdToken);
+
+        List<GrantedAuthority> authorities =
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_NONE"));
+        return new DefaultOidcUser(authorities, oidcIdToken);
+    }
+
+    private static void validateExpired(OidcIdToken oidcIdToken) {
+        Instant expiration = oidcIdToken.getExpiresAt();
+        if (expiration.isBefore(Instant.now())) {
+            throw new CustomException(ErrorCode.EXPIRED_JWT_TOKEN);
+        }
+    }
+
+    private void validateAudience(OidcIdToken oidcIdToken) {
+        String clientId = oidcIdToken.getAudience().get(0);
+        if (!properties.getId().equals(clientId)) {
+            throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateIssuer(OidcIdToken oidcIdToken) {
+        String issuer = oidcIdToken.getIssuer().toString();
+        if (!SecurityConstants.GOOGLE_ISSUER.equals(issuer)) {
+            throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private JwtDecoder buildDecoder() {
+        String jwkUrl = SecurityConstants.GOOGLE_JWK_SET_URL;
+        return NimbusJwtDecoder.withJwkSetUri(jwkUrl).build();
+    }
+}

--- a/src/main/java/com/pickkasso/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/pickkasso/domain/auth/application/JwtTokenService.java
@@ -1,0 +1,28 @@
+package com.pickkasso.domain.auth.application;
+
+import org.springframework.stereotype.Service;
+
+import com.pickkasso.domain.auth.dao.RefreshTokenRepository;
+import com.pickkasso.domain.auth.domain.RefreshToken;
+import com.pickkasso.domain.member.domain.MemberRole;
+import com.pickkasso.global.util.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String createAccessToken(Long memberId, MemberRole role) {
+        return jwtUtil.generateAccessToken(memberId, role);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        String token = jwtUtil.generateRefreshToken(memberId);
+        RefreshToken refreshToken = RefreshToken.builder().memberId(memberId).token(token).build();
+        refreshTokenRepository.save(refreshToken);
+        return token;
+    }
+}

--- a/src/main/java/com/pickkasso/domain/auth/dao/GoogleRefreshTokenRepository.java
+++ b/src/main/java/com/pickkasso/domain/auth/dao/GoogleRefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.pickkasso.domain.auth.dao;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.pickkasso.domain.auth.domain.GoogleRefreshToken;
+
+@Repository
+public interface GoogleRefreshTokenRepository extends CrudRepository<GoogleRefreshToken, Long> {}

--- a/src/main/java/com/pickkasso/domain/auth/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/pickkasso/domain/auth/dao/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.pickkasso.domain.auth.dao;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.pickkasso.domain.auth.domain.RefreshToken;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {}

--- a/src/main/java/com/pickkasso/domain/auth/domain/GoogleRefreshToken.java
+++ b/src/main/java/com/pickkasso/domain/auth/domain/GoogleRefreshToken.java
@@ -1,0 +1,25 @@
+package com.pickkasso.domain.auth.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class GoogleRefreshToken {
+    @Id private Long memberId;
+
+    private String token;
+
+    @Builder
+    public GoogleRefreshToken(Long memberId, String token) {
+        this.memberId = memberId;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/pickkasso/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/pickkasso/domain/auth/domain/RefreshToken.java
@@ -1,0 +1,23 @@
+package com.pickkasso.domain.auth.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+    @Id private Long memberId;
+
+    private String token;
+
+    @Builder
+    public RefreshToken(Long memberId, String token) {
+        this.memberId = memberId;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/pickkasso/domain/auth/dto/request/AuthCodeRequest.java
+++ b/src/main/java/com/pickkasso/domain/auth/dto/request/AuthCodeRequest.java
@@ -1,0 +1,12 @@
+package com.pickkasso.domain.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthCodeRequest {
+    private String code;
+}

--- a/src/main/java/com/pickkasso/domain/auth/dto/response/GoogleTokenResponse.java
+++ b/src/main/java/com/pickkasso/domain/auth/dto/response/GoogleTokenResponse.java
@@ -1,0 +1,13 @@
+package com.pickkasso.domain.auth.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class GoogleTokenResponse {
+    private String accessToken;
+    private String tokenType;
+    private String expiresIn;
+    private String refreshToken;
+    private String scope;
+    private String idToken;
+}

--- a/src/main/java/com/pickkasso/domain/auth/dto/response/TokenPairResponse.java
+++ b/src/main/java/com/pickkasso/domain/auth/dto/response/TokenPairResponse.java
@@ -1,0 +1,11 @@
+package com.pickkasso.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenPairResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/pickkasso/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/pickkasso/domain/member/dao/MemberRepository.java
@@ -1,9 +1,14 @@
 package com.pickkasso.domain.member.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.pickkasso.domain.member.domain.Member;
+import com.pickkasso.domain.member.domain.OauthInfo;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {}
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
+}

--- a/src/main/java/com/pickkasso/domain/member/domain/Member.java
+++ b/src/main/java/com/pickkasso/domain/member/domain/Member.java
@@ -19,23 +19,27 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(name = "sns_id")
-    private Long snsId;
-
     @Column(length = 10)
     private String nickname;
 
+    @Column
     @Enumerated(EnumType.STRING)
-    private SnsPlatform snsPlatform;
+    private MemberRole role;
+
+    @Embedded private OauthInfo oauthInfo;
 
     @Builder
-    private Member(Long snsId, String nickname, SnsPlatform snsPlatform) {
-        this.snsId = snsId;
+    private Member(String nickname, OauthInfo oauthInfo, MemberRole role) {
         this.nickname = nickname;
-        this.snsPlatform = snsPlatform;
+        this.role = role;
+        this.oauthInfo = oauthInfo;
     }
 
-    public static Member createMember(Long snsId, String nickname, SnsPlatform snsPlatform) {
-        return Member.builder().snsId(snsId).nickname(nickname).snsPlatform(snsPlatform).build();
+    public static Member createMember(OauthInfo oauthInfo, String nickname) {
+        return Member.builder()
+                .nickname(nickname)
+                .role(MemberRole.USER)
+                .oauthInfo(oauthInfo)
+                .build();
     }
 }

--- a/src/main/java/com/pickkasso/domain/member/domain/MemberRole.java
+++ b/src/main/java/com/pickkasso/domain/member/domain/MemberRole.java
@@ -5,9 +5,8 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum SnsPlatform {
-    NAVER("NAVER"),
-    KAKAO("KAKAO");
+public enum MemberRole {
+    USER("ROLE_USER");
 
     private final String value;
 }

--- a/src/main/java/com/pickkasso/domain/member/domain/OauthInfo.java
+++ b/src/main/java/com/pickkasso/domain/member/domain/OauthInfo.java
@@ -1,0 +1,33 @@
+package com.pickkasso.domain.member.domain;
+
+import jakarta.persistence.Embeddable;
+
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class OauthInfo {
+    private String oauthId;
+    private String oauthProvider;
+    private String oauthEmail;
+
+    @Builder
+    public OauthInfo(String oauthId, String oauthProvider, String oauthEmail) {
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+        this.oauthEmail = oauthEmail;
+    }
+
+    public static OauthInfo createOauthInfo(OidcUser user) {
+        return OauthInfo.builder()
+                .oauthId(user.getSubject())
+                .oauthProvider(user.getIssuer().toString())
+                .oauthEmail(user.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/pickkasso/global/common/constants/SecurityConstants.java
+++ b/src/main/java/com/pickkasso/global/common/constants/SecurityConstants.java
@@ -1,0 +1,11 @@
+package com.pickkasso.global.common.constants;
+
+public final class SecurityConstants {
+    public static final String TOKEN_ROLE_NAME = "role";
+
+    public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
+    public static final String GOOGLE_ISSUER = "https://accounts.google.com";
+    public static final String GOOGLE_JWK_SET_URL = "https://www.googleapis.com/oauth2/v3/certs";
+}

--- a/src/main/java/com/pickkasso/global/config/feign/GoogleFeignConfig.java
+++ b/src/main/java/com/pickkasso/global/config/feign/GoogleFeignConfig.java
@@ -1,0 +1,16 @@
+package com.pickkasso.global.config.feign;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import feign.RequestInterceptor;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.pickkasso.infra.config.feign")
+public class GoogleFeignConfig {
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return template -> template.header("Content-Type", "application/x-www-form-urlencoded");
+    }
+}

--- a/src/main/java/com/pickkasso/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/pickkasso/global/error/exception/ErrorCode.java
@@ -9,6 +9,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     SAMPLE_ERROR(HttpStatus.BAD_REQUEST, "Sample Error Message"),
+
+    ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/pickkasso/global/util/CookieUtil.java
+++ b/src/main/java/com/pickkasso/global/util/CookieUtil.java
@@ -1,0 +1,39 @@
+package com.pickkasso.global.util;
+
+import static com.pickkasso.global.common.constants.SecurityConstants.ACCESS_TOKEN_COOKIE_NAME;
+import static com.pickkasso.global.common.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+    public HttpHeaders generateTokenCookies(String accessToken, String refreshToken) {
+
+        String sameSite = Cookie.SameSite.NONE.attributeValue();
+
+        ResponseCookie accessTokenCookie =
+                ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
+                        .path("/")
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(true)
+                        .build();
+
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                        .path("/")
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+}

--- a/src/main/java/com/pickkasso/global/util/JwtUtil.java
+++ b/src/main/java/com/pickkasso/global/util/JwtUtil.java
@@ -1,0 +1,65 @@
+package com.pickkasso.global.util;
+
+import static com.pickkasso.global.common.constants.SecurityConstants.TOKEN_ROLE_NAME;
+
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+
+import com.pickkasso.domain.member.domain.MemberRole;
+import com.pickkasso.infra.config.jwt.JwtProperties;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+    private final JwtProperties jwtProperties;
+
+    public String generateAccessToken(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    private String buildAccessToken(
+            Long memberId, MemberRole memberRole, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.getIssuer())
+                .setSubject(memberId.toString())
+                .claim(TOKEN_ROLE_NAME, memberRole.name())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getAccessTokenKey())
+                .compact();
+    }
+
+    private String buildRefreshToken(Long memberId, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.getIssuer())
+                .setSubject(memberId.toString())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRefreshTokenKey())
+                .compact();
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getAccessTokenSecret().getBytes());
+    }
+
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getRefreshTokenSecret().getBytes());
+    }
+}

--- a/src/main/java/com/pickkasso/infra/config/feign/GoogleApiClient.java
+++ b/src/main/java/com/pickkasso/infra/config/feign/GoogleApiClient.java
@@ -1,0 +1,23 @@
+package com.pickkasso.infra.config.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.pickkasso.domain.auth.dto.response.GoogleTokenResponse;
+import com.pickkasso.global.config.feign.GoogleFeignConfig;
+
+@FeignClient(
+        name = "googleApiClient",
+        url = "https://oauth2.googleapis.com",
+        configuration = GoogleFeignConfig.class)
+public interface GoogleApiClient {
+    @PostMapping(value = "/token", produces = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    GoogleTokenResponse getToken(
+            @RequestParam("code") String code,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("grant_type") String grantType);
+}

--- a/src/main/java/com/pickkasso/infra/config/jwt/JwtProperties.java
+++ b/src/main/java/com/pickkasso/infra/config/jwt/JwtProperties.java
@@ -1,0 +1,25 @@
+package com.pickkasso.infra.config.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Setter
+public class JwtProperties {
+    private String accessTokenSecret;
+    private String refreshTokenSecret;
+    private Long accessTokenExpirationTime;
+    private Long refreshTokenExpirationTime;
+    private String issuer;
+
+    public Long accessTokenExpirationMilliTime() {
+        return accessTokenExpirationTime * 1000;
+    }
+
+    public Long refreshTokenExpirationMilliTime() {
+        return refreshTokenExpirationTime * 1000;
+    }
+}

--- a/src/main/java/com/pickkasso/infra/config/oauth/GoogleProperties.java
+++ b/src/main/java/com/pickkasso/infra/config/oauth/GoogleProperties.java
@@ -1,0 +1,15 @@
+package com.pickkasso.infra.config.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ConfigurationProperties(prefix = "oauth.google.client")
+@Getter
+@Setter
+public class GoogleProperties {
+    private String id;
+    private String secret;
+    private String redirectUri;
+}

--- a/src/main/java/com/pickkasso/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/pickkasso/infra/config/properties/PropertiesConfig.java
@@ -1,0 +1,11 @@
+package com.pickkasso.infra.config.properties;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import com.pickkasso.infra.config.jwt.JwtProperties;
+import com.pickkasso.infra.config.oauth.GoogleProperties;
+
+@EnableConfigurationProperties({GoogleProperties.class, JwtProperties.class})
+@Configuration
+public class PropertiesConfig {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    include:
+      - security
   datasource:
     url: jdbc:mysql://localhost:3306/pickkasso?createDatabaseIfNotExist=true
     username: root
@@ -14,6 +17,7 @@ spring:
         hbm2ddl:
           auto: update
         default_batch_fetch_size: 1000
+        show-sql: false
   jackson:
     property-naming-strategy: SNAKE_CASE
 


### PR DESCRIPTION
## 💡Issue
- Related Issue : #22 

## 📌Description
### 1. 구글 기준 소셜 로그인 구현
### 2. 클라이언트의 엑세스 토큰 만료 시 재발급 로직 구현
