### PR TITLE
fix : 클라이언트 도메인 임시 설정

### DIFF
--- a/src/main/java/com/pickkasso/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/pickkasso/global/config/security/WebSecurityConfig.java
@@ -53,6 +53,7 @@ public class WebSecurityConfig {
 
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
+        config.addAllowedOrigin("http://localhost:3000");
         config.setAllowCredentials(true);
         config.setAllowedHeaders(Collections.singletonList("*"));
         config.setMaxAge(3600L);


### PR DESCRIPTION
## 💡Issue
- Related Issue : #25 

## 📌Description
### 1. 클라이언트 도메인 임시 설정
- `localhost;3000` 으로 설정
