### PR TITLE
feat : 유저 프로필 소셜 연결

### DIFF
--- a/src/main/java/com/pickkasso/domain/member/application/MemberService.java
+++ b/src/main/java/com/pickkasso/domain/member/application/MemberService.java
@@ -15,6 +15,6 @@ public class MemberService {
 
     public MemberInfoResponse getMemberInfo() {
         final Member member = memberUtil.getCurrentMember();
-        return new MemberInfoResponse(member.getNickname(), member.getProfilelink());
+        return new MemberInfoResponse(member.getNickname(), member.getOauthInfo().getProfile());
     }
 }

--- a/src/main/java/com/pickkasso/domain/member/domain/Member.java
+++ b/src/main/java/com/pickkasso/domain/member/domain/Member.java
@@ -33,14 +33,11 @@ public class Member extends BaseEntity {
 
     @Embedded private OauthInfo oauthInfo;
 
-    @Column private String profilelink;
-
     @Builder
     private Member(String nickname, OauthInfo oauthInfo, MemberRole role) {
         this.nickname = nickname;
         this.role = role;
         this.oauthInfo = oauthInfo;
-        this.profilelink = null;
     }
 
     public static Member createMember(OauthInfo oauthInfo, String nickname) {

--- a/src/main/java/com/pickkasso/domain/member/domain/OauthInfo.java
+++ b/src/main/java/com/pickkasso/domain/member/domain/OauthInfo.java
@@ -15,12 +15,14 @@ public class OauthInfo {
     private String oauthId;
     private String oauthProvider;
     private String oauthEmail;
+    private String profile;
 
     @Builder
-    public OauthInfo(String oauthId, String oauthProvider, String oauthEmail) {
+    public OauthInfo(String oauthId, String oauthProvider, String oauthEmail, String profile) {
         this.oauthId = oauthId;
         this.oauthProvider = oauthProvider;
         this.oauthEmail = oauthEmail;
+        this.profile = profile;
     }
 
     public static OauthInfo createOauthInfo(OidcUser user) {
@@ -28,6 +30,7 @@ public class OauthInfo {
                 .oauthId(user.getSubject())
                 .oauthProvider(user.getIssuer().toString())
                 .oauthEmail(user.getEmail())
+                .profile(user.getAttributes().get("picture").toString())
                 .build();
     }
 }


### PR DESCRIPTION
## 💡Issue
- Related Issue : #25 

## 📌Description
### 1. 소셜 프로필 연결
- 구글의 id 토큰의 값으로 오는 프로필 링크를 유저의 프로필에 할당
