### PR TITLE
feat : 유저 회원탈퇴 구현

### DIFF
--- a/src/main/java/com/pickkasso/domain/member/api/MemberController.java
+++ b/src/main/java/com/pickkasso/domain/member/api/MemberController.java
@@ -1,11 +1,15 @@
 package com.pickkasso.domain.member.api;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.pickkasso.domain.member.application.MemberService;
 import com.pickkasso.domain.member.dto.response.MemberInfoResponse;
+import com.pickkasso.global.util.CookieUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,9 +18,18 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/users")
 public class MemberController {
     private final MemberService memberService;
+    private final CookieUtil cookieUtil;
 
     @GetMapping
     public MemberInfoResponse getMemberProfile() {
         return memberService.getMemberInfo();
+    }
+
+    @DeleteMapping("/withdrawal")
+    public ResponseEntity<Void> memberWithdrawal() {
+        memberService.withdrawal();
+        return ResponseEntity.status(HttpStatus.OK)
+                .headers(cookieUtil.deleteTokenCookies())
+                .build();
     }
 }

--- a/src/main/java/com/pickkasso/domain/member/application/MemberService.java
+++ b/src/main/java/com/pickkasso/domain/member/application/MemberService.java
@@ -2,6 +2,7 @@ package com.pickkasso.domain.member.application;
 
 import org.springframework.stereotype.Service;
 
+import com.pickkasso.domain.auth.dao.RefreshTokenRepository;
 import com.pickkasso.domain.member.domain.Member;
 import com.pickkasso.domain.member.dto.response.MemberInfoResponse;
 import com.pickkasso.global.util.MemberUtil;
@@ -12,9 +13,15 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class MemberService {
     private final MemberUtil memberUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public MemberInfoResponse getMemberInfo() {
         final Member member = memberUtil.getCurrentMember();
         return new MemberInfoResponse(member.getNickname(), member.getOauthInfo().getProfile());
+    }
+
+    public void withdrawal() {
+        final Member member = memberUtil.getCurrentMember();
+        refreshTokenRepository.deleteById(member.getId());
     }
 }

--- a/src/main/java/com/pickkasso/global/util/CookieUtil.java
+++ b/src/main/java/com/pickkasso/global/util/CookieUtil.java
@@ -36,4 +36,33 @@ public class CookieUtil {
 
         return headers;
     }
+
+    public HttpHeaders deleteTokenCookies() {
+
+        String sameSite = Cookie.SameSite.NONE.attributeValue();
+
+        ResponseCookie accessTokenCookie =
+                ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(false)
+                        .build();
+
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(false)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
 }


### PR DESCRIPTION
## 💡Issue
- Related Issue : #25 

## 📌Description
### 1. 유저 회원 탈퇴 구현
- 리프레시 토큰만 삭제 처리
