### PR TITLE
feat : 구글 드라이브 이미지 업로드 구현

### DIFF
--- a/src/main/java/com/pickkasso/domain/auth/application/AuthService.java
+++ b/src/main/java/com/pickkasso/domain/auth/application/AuthService.java
@@ -8,7 +8,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.pickkasso.domain.auth.dto.response.GoogleTokenResponse;
+import com.pickkasso.domain.auth.dto.response.GoogleLoginResponse;
 import com.pickkasso.domain.auth.dto.response.TokenPairResponse;
 import com.pickkasso.domain.member.dao.MemberRepository;
 import com.pickkasso.domain.member.domain.Member;
@@ -28,7 +28,7 @@ public class AuthService {
     private final JwtTokenService jwtTokenService;
 
     public TokenPairResponse socialLogin(String authcode) {
-        GoogleTokenResponse response = googleTokenService.getGoogleTokenResponse(authcode);
+        GoogleLoginResponse response = googleTokenService.getGoogleTokenResponse(authcode);
         OidcUser oidcUser = idTokenVerifier.getOidcUser(response.getIdToken());
         OauthInfo oauthInfo = OauthInfo.createOauthInfo(oidcUser);
 

--- a/src/main/java/com/pickkasso/domain/auth/application/GoogleTokenService.java
+++ b/src/main/java/com/pickkasso/domain/auth/application/GoogleTokenService.java
@@ -7,8 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.pickkasso.domain.auth.dao.GoogleRefreshTokenRepository;
 import com.pickkasso.domain.auth.domain.GoogleRefreshToken;
-import com.pickkasso.domain.auth.dto.response.GoogleTokenResponse;
+import com.pickkasso.domain.auth.dto.response.GoogleLoginResponse;
 import com.pickkasso.infra.config.feign.GoogleApiClient;
+import com.pickkasso.infra.config.feign.GoogleDriveApiClient;
 import com.pickkasso.infra.config.oauth.GoogleProperties;
 
 import lombok.RequiredArgsConstructor;
@@ -22,10 +23,11 @@ public class GoogleTokenService {
     private static final String AUTHORIZATION_CODE = "authorization_code";
 
     private final GoogleRefreshTokenRepository refreshTokenRepository;
+    private final GoogleDriveApiClient googleDriveApiClient;
     private final GoogleApiClient googleApiClient;
     private final GoogleProperties properties;
 
-    public GoogleTokenResponse getGoogleTokenResponse(String authcode) {
+    public GoogleLoginResponse getGoogleTokenResponse(String authcode) {
         return googleApiClient.getToken(
                 authcode,
                 properties.getId(),

--- a/src/main/java/com/pickkasso/domain/auth/dto/response/GoogleAccessTokenResponse.java
+++ b/src/main/java/com/pickkasso/domain/auth/dto/response/GoogleAccessTokenResponse.java
@@ -1,0 +1,14 @@
+package com.pickkasso.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GoogleAccessTokenResponse {
+    private String accessToken;
+    private String tokenType;
+    private String expireIn;
+    private String refreshToken;
+    private String scope;
+}

--- a/src/main/java/com/pickkasso/domain/auth/dto/response/GoogleLoginResponse.java
+++ b/src/main/java/com/pickkasso/domain/auth/dto/response/GoogleLoginResponse.java
@@ -3,7 +3,7 @@ package com.pickkasso.domain.auth.dto.response;
 import lombok.Getter;
 
 @Getter
-public class GoogleTokenResponse {
+public class GoogleLoginResponse {
     private String accessToken;
     private String tokenType;
     private String expiresIn;

--- a/src/main/java/com/pickkasso/domain/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/pickkasso/domain/curriculum/service/CurriculumService.java
@@ -86,7 +86,6 @@ public class CurriculumService {
         return userCurriculumListViewResponses;
     }
 
-
     public SelectedCurriculumResponse getSelectedCurriculum(long id, Member member) {
         Curriculum curriculum =
                 curriculumRepository

--- a/src/main/java/com/pickkasso/domain/painting/dto/response/GoogleDriveFileResponse.java
+++ b/src/main/java/com/pickkasso/domain/painting/dto/response/GoogleDriveFileResponse.java
@@ -1,0 +1,13 @@
+package com.pickkasso.domain.painting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GoogleDriveFileResponse {
+    private String id;
+    private String name;
+}

--- a/src/main/java/com/pickkasso/domain/painting/service/GoogleDriveService.java
+++ b/src/main/java/com/pickkasso/domain/painting/service/GoogleDriveService.java
@@ -1,0 +1,64 @@
+package com.pickkasso.domain.painting.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pickkasso.domain.auth.dao.GoogleRefreshTokenRepository;
+import com.pickkasso.domain.auth.domain.GoogleRefreshToken;
+import com.pickkasso.domain.auth.dto.response.GoogleAccessTokenResponse;
+import com.pickkasso.domain.painting.dto.response.GoogleDriveFileResponse;
+import com.pickkasso.global.common.constants.SecurityConstants;
+import com.pickkasso.global.error.exception.CustomException;
+import com.pickkasso.global.error.exception.ErrorCode;
+import com.pickkasso.infra.config.feign.GoogleApiClient;
+import com.pickkasso.infra.config.feign.GoogleDriveApiClient;
+import com.pickkasso.infra.config.oauth.GoogleProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class GoogleDriveService {
+    private static final String REFRESH_TOKEN = "refresh_token";
+    private static final String IMAGE_CONTENT_TYPE = "image/jpeg";
+
+    private final GoogleDriveApiClient googleDriveApiClient;
+    private final GoogleRefreshTokenRepository refreshTokenRepository;
+    private final GoogleProperties properties;
+    private final GoogleApiClient googleApiClient;
+
+    public void uploadToGoogleDrive(Long memberId, byte[] fileContent) {
+        GoogleAccessTokenResponse response = getAccessToken(memberId);
+        updateGoogleRefreshToken(memberId, response.getRefreshToken());
+        String accessToken = setBearer(response.getAccessToken());
+        GoogleDriveFileResponse uploadResponse =
+                googleDriveApiClient.uploadFile(accessToken, IMAGE_CONTENT_TYPE, fileContent);
+        log.info(uploadResponse.getId());
+        log.info(uploadResponse.getName());
+    }
+
+    public String setBearer(String accessToken) {
+        return SecurityConstants.TOKEN_PREFIX.concat(accessToken);
+    }
+
+    private void updateGoogleRefreshToken(Long memberId, String newRefreshToken) {
+        GoogleRefreshToken googleRefreshToken =
+                refreshTokenRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+        googleRefreshToken.setToken(newRefreshToken);
+        refreshTokenRepository.save(googleRefreshToken);
+    }
+
+    private GoogleAccessTokenResponse getAccessToken(Long memberId) {
+        GoogleRefreshToken refreshToken =
+                refreshTokenRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+        return googleApiClient.getAccessToken(
+                refreshToken.getToken(), properties.getId(), properties.getSecret(), REFRESH_TOKEN);
+    }
+}

--- a/src/main/java/com/pickkasso/domain/painting/service/PaintingService.java
+++ b/src/main/java/com/pickkasso/domain/painting/service/PaintingService.java
@@ -42,6 +42,7 @@ public class PaintingService {
     private final RoundRepository roundRepository;
     private final CurriculumRepository curriculumRepository;
     private final MemberRepository memberRepository;
+    private final GoogleDriveService googleDriveService;
 
     public Painting uploadPainting(
             MultipartFile file, AddPaintingRequest addPaintingRequest, Long memberId)
@@ -61,10 +62,12 @@ public class PaintingService {
 
         paintingRepository.save(painting);
 
-
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(file.getSize());
         s3Client.putObject(bucket, fileName, file.getInputStream(), metadata);
+
+        byte[] fileContent = file.getBytes();
+        googleDriveService.uploadToGoogleDrive(memberId, fileContent);
 
         return paintingRepository.save(painting);
     }
@@ -114,6 +117,4 @@ public class PaintingService {
         }
         return userPaintingListViewResponses;
     }
-
-
 }

--- a/src/main/java/com/pickkasso/global/common/constants/SecurityConstants.java
+++ b/src/main/java/com/pickkasso/global/common/constants/SecurityConstants.java
@@ -2,6 +2,7 @@ package com.pickkasso.global.common.constants;
 
 public final class SecurityConstants {
     public static final String TOKEN_ROLE_NAME = "role";
+    public static final String TOKEN_PREFIX = "Bearer ";
 
     public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";

--- a/src/main/java/com/pickkasso/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/pickkasso/global/error/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
 
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰 정보가 유효하지 않습니다."),
 
     AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보를 찾을 수 없습니다."),
 

--- a/src/main/java/com/pickkasso/infra/config/feign/GoogleApiClient.java
+++ b/src/main/java/com/pickkasso/infra/config/feign/GoogleApiClient.java
@@ -5,7 +5,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.pickkasso.domain.auth.dto.response.GoogleTokenResponse;
+import com.pickkasso.domain.auth.dto.response.GoogleAccessTokenResponse;
+import com.pickkasso.domain.auth.dto.response.GoogleLoginResponse;
 import com.pickkasso.global.config.feign.GoogleFeignConfig;
 
 @FeignClient(
@@ -14,10 +15,17 @@ import com.pickkasso.global.config.feign.GoogleFeignConfig;
         configuration = GoogleFeignConfig.class)
 public interface GoogleApiClient {
     @PostMapping(value = "/token", produces = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    GoogleTokenResponse getToken(
+    GoogleLoginResponse getToken(
             @RequestParam("code") String code,
             @RequestParam("client_id") String clientId,
             @RequestParam("client_secret") String clientSecret,
             @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("grant_type") String grantType);
+
+    @PostMapping(value = "/token", produces = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    GoogleAccessTokenResponse getAccessToken(
+            @RequestParam("refresh_token") String refreshToken,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
             @RequestParam("grant_type") String grantType);
 }

--- a/src/main/java/com/pickkasso/infra/config/feign/GoogleDriveApiClient.java
+++ b/src/main/java/com/pickkasso/infra/config/feign/GoogleDriveApiClient.java
@@ -1,0 +1,24 @@
+package com.pickkasso.infra.config.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import com.pickkasso.domain.painting.dto.response.GoogleDriveFileResponse;
+import com.pickkasso.global.config.feign.GoogleFeignConfig;
+
+@FeignClient(
+        name = "googleDriveApiClient",
+        url = "https://www.googleapis.com/upload/drive/v3",
+        configuration = GoogleFeignConfig.class)
+public interface GoogleDriveApiClient {
+    @PostMapping(
+            value = "/files?uploadType=media",
+            consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    GoogleDriveFileResponse uploadFile(
+            @RequestHeader("Authorization") String authorization,
+            @RequestHeader("Content-Type") String contentType,
+            @RequestBody byte[] fileContent);
+}


### PR DESCRIPTION
## 💡Issue
- Related Issue : #45 

## 📌Description
### 1. 구글 드라이브 이미지 업로드 구현
- 이미지 업로드 api 중간에 추가
- 가지고 있던 구글 서비스 리프레시 토큰으로 엑세스 토큰 재발급 이후 사용
- 재발급 리프레시 토큰 재저장
